### PR TITLE
[FIX] Fix build options

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -5,6 +5,9 @@ const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 module.exports = function (defaults) {
   const app = new EmberApp(defaults, {
     // Add options here
+    fingerprint: {
+      extensions: ['js', 'css', 'png', 'jpg', 'json'],
+    },
   });
 
   return app.toTree();


### PR DESCRIPTION
### What's in this PR ?

When deploying to GH page, we meet this error
`SyntaxError: Unexpected token '<', "<!DOCTYPE "... is not valid JSON`

When looking at the sources in the console, `elements.json` is missing. It seems JSON files are excluded from the `build `step.

In this PR we add an option in ember-cli-build.js file to add JSON files into the build process.