### PR TITLE
[FIX] Fix fetch URL

### DIFF
--- a/app/services/store-elements.js
+++ b/app/services/store-elements.js
@@ -1,12 +1,15 @@
 import Service from '@ember/service';
 import Element from 'ember-periodic-table/models/element';
 import { tracked } from '@glimmer/tracking';
+import config from 'ember-periodic-table/config/environment';
+
+const { rootURL } = config;
 
 export default class StoreElementsService extends Service {
   @tracked elements = undefined;
 
   async fetchElements() {
-    let response = await fetch('/assets/elements.json');
+    let response = await fetch(`${rootURL}assets/elements.json`);
     let elementsJSON = await response.json();
     this.elements = elementsJSON.elements.map(
       (element) => new Element(element),


### PR DESCRIPTION
### What's in this PR ?

While trying to deploy to GH pages, we keep running into a 404 error about the `elements.json` file.
In the code, we were trying to fetch this URL `/assets/elements.json` but the file was actually stored in `ember-periodic-table/assets/elements.json`.

We fixed this by adding the `rootURL` value at the start of the fetched URL. `RootURL` is a simple `/` in local and `ember-periodic-table` in production (Value set in `environment.js` file)